### PR TITLE
Add featured post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@astrojs/starlight": "^0.24.0",
         "astro": "^4.9.3",
         "sharp": "^0.32.5",
-        "starlight-blog": "^0.8.0"
+        "starlight-blog": "^0.12.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8773,9 +8773,9 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/starlight-blog": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/starlight-blog/-/starlight-blog-0.8.0.tgz",
-      "integrity": "sha512-OhNphIlNaW1MrPPVIO9dm6thw1SFJ2Yj7Paoe8N2saX6hZhka58ZBbjdiBX5noJCLa+nkAXB1hHC6Q4Ak7gxIQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/starlight-blog/-/starlight-blog-0.12.0.tgz",
+      "integrity": "sha512-SSNkBQIM6RrumGQQqOv76L5Lcefm6faU2+4armlgQh2zod24aOvuCGUcFi3F//DxOWvIx3WRb7X/VRqs3yNO8A==",
       "dependencies": {
         "@astrojs/rss": "4.0.5",
         "astro-remote": "0.3.2",
@@ -8788,8 +8788,8 @@
         "node": ">=18.14.1"
       },
       "peerDependencies": {
-        "@astrojs/starlight": ">=0.22.1",
-        "astro": ">=4.2.7"
+        "@astrojs/starlight": ">=0.24.0",
+        "astro": ">=4.8.6"
       }
     },
     "node_modules/stdin-discarder": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "@astrojs/starlight": "^0.24.0",
     "astro": "^4.9.3",
     "sharp": "^0.32.5",
-    "starlight-blog": "^0.8.0"
+    "starlight-blog": "^0.12.0"
   }
 }

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -3,6 +3,6 @@ import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
 import { blogSchema } from 'starlight-blog/schema';
 
 export const collections = {
-	docs: defineCollection({ schema: docsSchema({ extend: blogSchema() }) }),
+	docs: defineCollection({ schema: docsSchema({ extend: (context) => blogSchema(context) }) }),
 	i18n: defineCollection({ type: 'data', schema: i18nSchema() }),
 };

--- a/src/content/docs/blog/50-docs-tips-in-50-days.md
+++ b/src/content/docs/blog/50-docs-tips-in-50-days.md
@@ -6,6 +6,9 @@ date: 2024-06-24
 pubDate: '2024-06-24'
 excerpt: "It's 50 days until I turn 50! So I thought I'd celebrate with a different docs tip every day."
 tags: ["docs", "50 tips in 50 days"]
+featured: true
+prev: false
+next: false
 ---
 I realized while working *on* this site that it's been a while since I've written *for* this site!
 


### PR DESCRIPTION
This PR updates `starlight-blog` to its [latest version](https://github.com/HiDeoo/starlight-blog/releases/tag/v0.12.0) which includes support for featured posts.

The following changes were made:

- Updates the `src/content/config.ts` file to the new format introduced in [`starlight-blog@0.9.0`](https://github.com/HiDeoo/starlight-blog/releases/tag/v0.9.0).
- Adds the `featured` field to the `src/content/docs/blog/50-docs-tips-in-50-days.md` blog post.

In the sidebar, this appears as a new section called "Featured posts" and in the blog post list, the featured post includes a badge.

<img width="291" alt="image" src="https://github.com/user-attachments/assets/69cdb8a7-0150-4b9e-8625-c9a18e42c50d">
<img width="646" alt="image" src="https://github.com/user-attachments/assets/97f8e69c-3da7-4c38-9722-abfb2020a74e">

I also added `prev: false` & `next: false` to this post, as you manually added this post to your documentation sidebar, the page was getting double navigation links in the footer. The change fixes that so only the blog ones are visible:

| Before          | After           |
| --------------- | --------------- |
| <img width="747" alt="image" src="https://github.com/user-attachments/assets/c956df76-331f-430e-8e32-ac87e410b422"> | <img width="748" alt="image" src="https://github.com/user-attachments/assets/cecd6c11-2f28-47b4-a3d1-500e90fb32c5"> |

Feels free to let me know if you want me to remove it.