### PR TITLE
fix mastodon author attribution

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -35,7 +35,7 @@ export default defineConfig({
               },
               {tag: "meta", 
                 attrs: {
-                    name: "fedierse:creator", 
+                    name: "fediverse:creator", 
                     content: "@sarah11918@mastodon.social",
                 }
               },


### PR DESCRIPTION
I'm not sure if Mastodon uses different names in the meta tag, but I'm currently setting up mine and it says `fediverse` with an `v` and I think you forgot it... I'm just creating this PR to let you know, hope it helps!